### PR TITLE
feat: add color themes with dark/light toggle

### DIFF
--- a/docs/plans/2026-03-02-feat-color-themes-plan.md
+++ b/docs/plans/2026-03-02-feat-color-themes-plan.md
@@ -1,0 +1,162 @@
+---
+title: "feat: Color themes"
+type: feat
+date: 2026-03-02
+issue: 7
+depends_on: []
+---
+
+# feat: Color themes (#7)
+
+## Overview
+
+Extract all hardcoded color and style definitions from `src/tui/app.rs` into a centralized `Theme` struct, provide built-in dark and light palettes, and add a runtime toggle (`T`) to switch between them.
+
+## Problem Statement / Motivation
+
+The TUI currently has 15+ inline `Style` definitions scattered across 6 draw methods in a 3,329-line file. Only 4 named colors are used (`Cyan`, `DarkGray`, `Gray`, `Yellow`), all hardcoded. This makes it impossible to:
+
+- Switch between dark and light appearances
+- Let users customize the color scheme
+- Maintain visual consistency (duplicate style expressions across methods)
+- Ensure readability on light terminal backgrounds (e.g., `Color::Yellow` text is invisible on white)
+
+## Proposed Solution
+
+### Architecture
+
+Create `src/tui/theme.rs` with:
+
+1. **`Theme` struct** -- flat struct mapping 10 semantic UI roles to `ratatui::style::Style` values, plus an `is_dark: bool` field for identity
+2. **Built-in constructors** -- `Theme::dark()` and `Theme::light()` using named terminal colors
+3. **`toggle()` method** -- on `Theme` itself; returns the opposite theme. No separate enum needed.
+4. **Runtime toggle** -- `T` (shift+t) in `Mode::Normal` calls `self.theme = self.theme.toggle()`; ratatui's immediate-mode rendering applies it on the next frame
+
+### Semantic Role Mapping
+
+Only roles that have a non-default, non-duplicate value today. Roles are added when the UI gains a visual distinction that requires them.
+
+| Theme Field | Current Style | Used In |
+|---|---|---|
+| `active_border` | `fg(Cyan)` | Focused pane border, active tab text |
+| `inactive_border` | `Style::default()` | Non-focused pane borders, inactive tab text |
+| `inactive_tab` | `fg(DarkGray)` | Non-current screen tab text |
+| `help_key` | `fg(Cyan) bg(DarkGray) BOLD` | Keyboard shortcut labels in help bar |
+| `help_desc` | `fg(Gray)` | Shortcut descriptions in help bar |
+| `highlight` | `REVERSED` | Cursor line (content, settings, library), tree selection |
+| `visual_selection` | `bg(DarkGray)` | Selected text range in visual select mode |
+| `input_border` | `fg(Yellow)` | Title input, rename input, edit mode borders |
+| `edit_cursor_line` | `UNDERLINED` | Active line in tui-textarea editor |
+| `active_tab` | `fg(Cyan) + BOLD` | Current screen tab text |
+
+**Consolidated roles (reviewer feedback):**
+- `cursor` + `tree_highlight` merged into `highlight` -- both are `REVERSED`
+- `input_border` + `edit_border` merged into `input_border` -- both are `fg(Yellow)`
+- `normal_text`, `status_bar`, `error_text`, `placeholder_text`, `scrollbar` removed -- all are `Style::default()` in both themes; add when they diverge
+
+**Pre-implementation audit:** Before starting, run `rg "Style::default\(\)|fg\(|bg\(|Modifier::" src/tui/app.rs` to produce the definitive list and catch any missed sites.
+
+### Key Decisions
+
+- **No `ThemeMode` enum.** `Theme` stores `is_dark: bool`. Toggle swaps the struct directly: `self.theme = self.theme.toggle()`. One type, zero indirection.
+- **Toggle key:** `T` (shift+t), active only in `Mode::Normal`. Avoids conflict with future vim-style lowercase bindings.
+- **Module location:** `src/tui/theme.rs`, exported via `src/tui/mod.rs`.
+- **Color strategy:** Named terminal colors (`Color::Cyan`, `Color::Blue`, etc.) for built-in themes. Respects user's terminal palette.
+- **Theme storage:** `theme: Theme` stored directly on `App`. Draw methods access `self.theme`.
+- **No auto-detection:** Always starts in dark mode.
+- **No persistence:** Theme resets to dark on restart until #6 config support lands.
+- **Derives:** `Theme` derives `Debug`, `Clone`, `PartialEq`.
+
+## Technical Considerations
+
+### ratatui Integration
+
+- ratatui is immediate-mode: swapping `self.theme` takes effect on the very next `draw()` call with zero additional work
+- `tui-textarea::TextArea` has its own styling API (`set_cursor_line_style`, `set_block`). The theme must be applied when creating the `TextArea` in `enter_edit_mode()`. Since `T` does not fire in edit mode, the textarea is always freshly created with the current theme.
+
+### Light Theme Color Choices
+
+The light theme must avoid colors that are invisible on white/light backgrounds:
+
+| Role | Dark Theme | Light Theme | Rationale |
+|---|---|---|---|
+| Active border/tab | `Cyan` | `Blue` | Better contrast on white |
+| Inactive elements | `DarkGray` | `Gray` | Slightly darker for visibility |
+| Input border | `Yellow` | `Magenta` | Yellow on white is invisible |
+| Visual selection bg | `DarkGray` | `LightYellow` | Visible highlight on light bg |
+| Highlight | `REVERSED` | `REVERSED` | Modifier-only, works everywhere |
+
+### Testing Strategy
+
+- **Unit tests in `src/tui/theme.rs`:** Assert that `Theme::dark()` and `Theme::light()` return expected `Style` values for each field. Assert `toggle()` flips `is_dark` and returns the opposite palette. These are fast, isolated, and meaningful.
+- **Existing tests pass unchanged:** Dark theme uses the exact same color values as current hardcoded styles, so all existing `TestBackend` assertions (e.g., `Modifier::REVERSED`) continue to pass.
+- **No preemptive `TestBackend` cell-color tests.** Cell-level color assertions tie tests to exact buffer coordinates and break on any layout change. Add them only if a visual regression actually occurs.
+- **Testable `App` construction:** `App::new()` takes `Vec<SourceRoot>`, which can be constructed with empty vecs in tests. No filesystem access required.
+
+## Acceptance Criteria
+
+- [x] New `src/tui/theme.rs` module with `Theme` struct (10 fields + `is_dark`)
+- [x] `Theme::dark()` matches current visual appearance (backward compatible)
+- [x] `Theme::light()` is readable on light terminal backgrounds
+- [x] `Theme::toggle()` returns the opposite theme
+- [x] All draw methods use `self.theme` -- zero hardcoded `Color::*` or `Style::default().fg(...)` remaining
+- [x] `T` (shift+t) toggles theme in `Mode::Normal` on both screens
+- [x] Help bar shows `T Theme` in Normal mode on both screens
+- [x] All existing tests pass without modification
+
+## Implementation Phases
+
+All phases are sequential TDD cycles within a single PR. The value is delivered when `T` toggles between working themes.
+
+### Phase 1: Theme Struct, Dark Palette, and Wire-up (TDD)
+
+**Files:** `src/tui/theme.rs`, `src/tui/mod.rs`, `src/tui/app.rs`
+
+1. Run `rg` audit to confirm the definitive list of styling sites
+2. Write failing test: `Theme::dark().active_border` returns expected style
+3. Create `Theme` struct with 10 semantic fields + `is_dark`, derive `Debug`, `Clone`, `PartialEq`
+4. Implement `Theme::dark()` matching current hardcoded values exactly
+5. Implement `Theme::toggle()` method
+6. Add tests for all fields and toggle behavior
+7. Add `theme: Theme` to `App`, initialize with `Theme::dark()` in `App::new()`
+8. Replace inline styles in draw methods with `self.theme.<field>`, one method at a time:
+   `draw_tab_bar()` -> `draw_files_screen()` borders -> `draw_content_pane()` -> `draw_settings_screen()` -> `draw_library_pane()` -> `help_line()` -> `draw()` input/status bars
+9. After each replacement, verify existing tests still pass
+
+### Phase 2: Light Theme and Toggle (TDD)
+
+**Files:** `src/tui/theme.rs`, `src/tui/app.rs`
+
+1. Write failing test: `Theme::light().active_border` differs from dark
+2. Implement `Theme::light()` with light-appropriate colors
+3. Write failing test: pressing `T` in Normal mode changes `self.theme.is_dark`
+4. Add `T` handler in `handle_key_event()` at the same level as screen-switch keys (`1`/`2`), guarded by `Mode::Normal`
+5. Add `T Theme` to help bar in Normal mode on both screens
+6. Update `enter_edit_mode()` to use `self.theme.edit_cursor_line` and `self.theme.input_border`
+7. Final `rg` pass: grep for any remaining `Color::` or `Style::default().fg` in draw methods
+8. Clippy + full test pass
+
+## Dependencies and Risks
+
+**No new crate dependencies required.** The implementation uses only existing `ratatui::style` types.
+
+**Risk: Large refactor surface.** Touching all 6 draw methods in a 3,329-line file. Mitigated by incremental TDD -- one style replacement per cycle.
+
+**Risk: Visual regression.** Dark theme must look identical to current app. Mitigated by `Theme::dark()` using the exact same color values as current hardcoded styles.
+
+**Deferred:** Custom TOML themes, terminal background auto-detection, theme persistence, catppuccin integration, `error_text`/`placeholder_text`/`scrollbar` theme roles -- all wait for #6 or until the UI gains non-default styles for them.
+
+## References and Research
+
+### Internal References
+
+- Current styling: `src/tui/app.rs` -- 15+ inline `Style` definitions across lines 329-919
+- Brainstorm: `docs/brainstorms/2026-02-27-context-manager-brainstorm.md` (line 86: themes listed as future)
+- Issue #6: Configuration file support (open, deferred dependency)
+
+### External References
+
+- [gitui theme system](https://github.com/extrawurst/gitui/blob/master/THEMES.md) -- flat semantic-field struct pattern (adopted)
+- [Yazi theme.toml](https://yazi-rs.github.io/docs/configuration/theme/) -- hierarchical nested struct pattern (rejected as overkill)
+- [ratatui Style docs](https://docs.rs/ratatui/latest/ratatui/style/struct.Style.html)
+- [ratatui serde feature](https://ratatui.rs/installation/feature-flags/) -- built-in Color/Style serialization (for future TOML support)

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -15,7 +15,6 @@ use ratatui::crossterm::event::KeyModifiers;
 use ratatui::layout::Constraint;
 use ratatui::layout::Direction;
 use ratatui::layout::Layout;
-use ratatui::style::Color;
 use ratatui::style::Modifier;
 use ratatui::style::Style;
 use ratatui::text::Line;
@@ -38,6 +37,7 @@ use crate::settings::SettingsCollection;
 use crate::settings::SettingsFile;
 use crate::settings::SettingsLineMap;
 use crate::settings::format_settings_with_map;
+use crate::tui::theme::Theme;
 
 pub type TreeId = String;
 
@@ -268,6 +268,7 @@ pub struct App {
     pub settings_state: SettingsState,
     pub settings_collection: Option<SettingsCollection>,
     pub edit_state: Option<EditState>,
+    pub theme: Theme,
 }
 
 impl App {
@@ -311,6 +312,7 @@ impl App {
             settings_state: SettingsState::default(),
             settings_collection: None,
             edit_state: None,
+            theme: Theme::dark(),
         };
 
         app.load_selected_content();
@@ -326,11 +328,8 @@ impl App {
     }
 
     fn help_line(&self) -> Line<'static> {
-        let key_style = Style::default()
-            .fg(Color::Cyan)
-            .bg(Color::DarkGray)
-            .add_modifier(Modifier::BOLD);
-        let desc_style = Style::default().fg(Color::Gray);
+        let key_style = self.theme.help_key;
+        let desc_style = self.theme.help_desc;
         let sep = Span::styled("  ", desc_style);
 
         let pairs: Vec<(&str, &str)> = match self.screen {
@@ -343,6 +342,7 @@ impl App {
                     ("2", "Settings"),
                     ("m", "Per-file"),
                     ("j/k", "Scroll"),
+                    ("T", "Theme"),
                     ("q", "Quit"),
                 ]
             }
@@ -353,6 +353,7 @@ impl App {
                     ("e", "Edit"),
                     ("m", "Merge"),
                     ("j/k", "Scroll"),
+                    ("T", "Theme"),
                     ("q", "Quit"),
                 ]
             }
@@ -367,6 +368,7 @@ impl App {
                         ("e", "Edit"),
                         ("v", "Select"),
                         ("L", "Library"),
+                        ("T", "Theme"),
                     ]
                 }
                 Mode::Normal => {
@@ -376,6 +378,7 @@ impl App {
                         ("q", "Quit"),
                         ("Tab", "Content"),
                         ("j/k", "Navigate"),
+                        ("T", "Theme"),
                     ]
                 }
                 Mode::VisualSelect => {
@@ -453,7 +456,7 @@ impl App {
                 let input_widget = Paragraph::new(self.title_input.as_str()).block(
                     Block::default()
                         .borders(Borders::ALL)
-                        .border_style(Style::default().fg(Color::Yellow))
+                        .border_style(self.theme.input_border)
                         .title(bar_title),
                 );
                 frame.render_widget(input_widget, bar_area);
@@ -474,10 +477,8 @@ impl App {
     }
 
     fn draw_tab_bar(&self, frame: &mut Frame, area: ratatui::layout::Rect) {
-        let active_style = Style::default()
-            .fg(Color::Cyan)
-            .add_modifier(Modifier::BOLD);
-        let inactive_style = Style::default().fg(Color::DarkGray);
+        let active_style = self.theme.active_tab;
+        let inactive_style = self.theme.inactive_tab;
 
         let files_style = if self.screen == Screen::Files {
             active_style
@@ -510,15 +511,15 @@ impl App {
             .split(area);
 
         let file_border_style = if self.active_pane == Pane::FileList {
-            Style::default().fg(Color::Cyan)
+            self.theme.active_border
         } else {
-            Style::default()
+            self.theme.inactive_border
         };
 
         let content_border_style = if self.active_pane == Pane::Content {
-            Style::default().fg(Color::Cyan)
+            self.theme.active_border
         } else {
-            Style::default()
+            self.theme.inactive_border
         };
 
         if let Ok(tree) = Tree::new(&self.tree_items) {
@@ -529,7 +530,7 @@ impl App {
                         .border_style(file_border_style)
                         .title("CLAUDE.md files"),
                 )
-                .highlight_style(Style::default().add_modifier(Modifier::REVERSED));
+                .highlight_style(self.theme.highlight);
             frame.render_stateful_widget(tree, chunks[0], &mut self.tree_state);
         }
 
@@ -549,7 +550,7 @@ impl App {
         self.settings_state.viewport_height = area.height.saturating_sub(2);
 
         let cursor_line = self.settings_state.cursor;
-        let cursor_style = Style::default().add_modifier(Modifier::REVERSED);
+        let cursor_style = self.theme.highlight;
 
         let lines: Vec<Line> = self
             .settings_state
@@ -611,8 +612,8 @@ impl App {
         let selection = self.content.selection_range();
         let cursor_line = self.content.cursor;
         let show_cursor = self.active_pane == Pane::Content;
-        let cursor_style = Style::default().add_modifier(Modifier::REVERSED);
-        let highlight_style = Style::default().bg(Color::DarkGray);
+        let cursor_style = self.theme.highlight;
+        let highlight_style = self.theme.visual_selection;
 
         let lines: Vec<Line> = display_text
             .lines()
@@ -693,7 +694,7 @@ impl App {
             .enumerate()
             .map(|(i, snippet)| {
                 let style = if i == self.library_selected {
-                    Style::default().add_modifier(Modifier::REVERSED)
+                    self.theme.highlight
                 } else {
                     Style::default()
                 };
@@ -751,7 +752,7 @@ impl App {
         edit.textarea.set_block(
             Block::default()
                 .borders(Borders::ALL)
-                .border_style(Style::default().fg(Color::Yellow))
+                .border_style(self.theme.input_border)
                 .title(title),
         );
 
@@ -916,7 +917,7 @@ impl App {
 
         let mut textarea = TextArea::new(lines);
         textarea.set_tab_length(4);
-        textarea.set_cursor_line_style(Style::default().add_modifier(Modifier::UNDERLINED));
+        textarea.set_cursor_line_style(self.theme.edit_cursor_line);
 
         self.edit_state = Some(EditState {
             textarea,
@@ -1099,7 +1100,7 @@ impl App {
             return;
         }
 
-        // Screen switching only in Normal mode
+        // Screen switching and theme toggle only in Normal mode
         if self.mode == Mode::Normal {
             match key_event.code {
                 KeyCode::Char('1') => {
@@ -1108,6 +1109,10 @@ impl App {
                 }
                 KeyCode::Char('2') => {
                     self.switch_to_settings();
+                    return;
+                }
+                KeyCode::Char('T') => {
+                    self.theme = self.theme.toggle();
                     return;
                 }
                 _ => {}
@@ -3325,5 +3330,72 @@ mod tests {
             saved, original_content,
             "File without trailing newline should stay without one"
         );
+    }
+
+    #[test]
+    fn shift_t_toggles_theme_in_normal_mode() {
+        let mut app = App::new(vec![]);
+        assert!(app.theme.is_dark);
+
+        let shift_t = KeyEvent {
+            code: KeyCode::Char('T'),
+            modifiers: KeyModifiers::SHIFT,
+            kind: KeyEventKind::Press,
+            state: KeyEventState::empty(),
+        };
+        app.handle_key_event(shift_t);
+        assert!(!app.theme.is_dark, "Theme should toggle to light");
+
+        app.handle_key_event(shift_t);
+        assert!(app.theme.is_dark, "Theme should toggle back to dark");
+    }
+
+    #[test]
+    fn shift_t_ignored_in_edit_mode() {
+        let mut app = App::new(vec![]);
+        // Force into edit mode by setting mode directly
+        app.mode = Mode::Edit;
+
+        let shift_t = KeyEvent {
+            code: KeyCode::Char('T'),
+            modifiers: KeyModifiers::SHIFT,
+            kind: KeyEventKind::Press,
+            state: KeyEventState::empty(),
+        };
+        app.handle_key_event(shift_t);
+        assert!(app.theme.is_dark, "Theme should not toggle in edit mode");
+    }
+
+    #[test]
+    fn shift_t_ignored_in_title_input_mode() {
+        let mut app = App::new(vec![]);
+        app.mode = Mode::TitleInput;
+
+        let shift_t = KeyEvent {
+            code: KeyCode::Char('T'),
+            modifiers: KeyModifiers::SHIFT,
+            kind: KeyEventKind::Press,
+            state: KeyEventState::empty(),
+        };
+        app.handle_key_event(shift_t);
+        assert!(
+            app.theme.is_dark,
+            "Theme should not toggle in title input mode"
+        );
+    }
+
+    #[test]
+    fn shift_t_toggles_on_settings_screen() {
+        let mut app = App::new(vec![]);
+        app.screen = Screen::Settings;
+
+        let shift_t = KeyEvent {
+            code: KeyCode::Char('T'),
+            modifiers: KeyModifiers::SHIFT,
+            kind: KeyEventKind::Press,
+            state: KeyEventState::empty(),
+        };
+        app.handle_key_event(shift_t);
+        assert!(!app.theme.is_dark, "Theme should toggle on settings screen");
     }
 }

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -1,1 +1,2 @@
 pub mod app;
+pub mod theme;

--- a/src/tui/theme.rs
+++ b/src/tui/theme.rs
@@ -1,0 +1,176 @@
+/// Color theme definitions for the TUI.
+///
+/// Maps semantic UI roles to `ratatui::style::Style` values. Provides
+/// built-in dark and light palettes and a `toggle()` method to swap between
+/// them at runtime.
+use ratatui::style::Color;
+use ratatui::style::Modifier;
+use ratatui::style::Style;
+
+/// Maps every visual role in the application to a concrete [`Style`].
+#[derive(Debug, Clone, PartialEq)]
+pub struct Theme {
+    /// Whether this is the dark variant.
+    pub is_dark: bool,
+    /// Focused pane border and active tab text.
+    pub active_border: Style,
+    /// Non-focused pane borders.
+    pub inactive_border: Style,
+    /// Active screen tab text.
+    pub active_tab: Style,
+    /// Inactive screen tab text.
+    pub inactive_tab: Style,
+    /// Keyboard shortcut labels in the help bar.
+    pub help_key: Style,
+    /// Shortcut descriptions in the help bar.
+    pub help_desc: Style,
+    /// Cursor line and selected tree/list item.
+    pub highlight: Style,
+    /// Selected text range in visual select mode.
+    pub visual_selection: Style,
+    /// Border for input fields and edit mode.
+    pub input_border: Style,
+    /// Active line in the text editor.
+    pub edit_cursor_line: Style,
+}
+
+impl Theme {
+    /// Returns the built-in dark palette matching the original hardcoded styles.
+    pub fn dark() -> Self {
+        Self {
+            is_dark: true,
+            active_border: Style::default().fg(Color::Cyan),
+            inactive_border: Style::default(),
+            active_tab: Style::default()
+                .fg(Color::Cyan)
+                .add_modifier(Modifier::BOLD),
+            inactive_tab: Style::default().fg(Color::DarkGray),
+            help_key: Style::default()
+                .fg(Color::Cyan)
+                .bg(Color::DarkGray)
+                .add_modifier(Modifier::BOLD),
+            help_desc: Style::default().fg(Color::Gray),
+            highlight: Style::default().add_modifier(Modifier::REVERSED),
+            visual_selection: Style::default().bg(Color::DarkGray),
+            input_border: Style::default().fg(Color::Yellow),
+            edit_cursor_line: Style::default().add_modifier(Modifier::UNDERLINED),
+        }
+    }
+
+    /// Returns the built-in light palette with colors readable on light
+    /// terminal backgrounds.
+    pub fn light() -> Self {
+        Self {
+            is_dark: false,
+            active_border: Style::default().fg(Color::Blue),
+            inactive_border: Style::default().fg(Color::Gray),
+            active_tab: Style::default()
+                .fg(Color::Blue)
+                .add_modifier(Modifier::BOLD),
+            inactive_tab: Style::default().fg(Color::Gray),
+            help_key: Style::default()
+                .fg(Color::White)
+                .bg(Color::Blue)
+                .add_modifier(Modifier::BOLD),
+            help_desc: Style::default().fg(Color::DarkGray),
+            highlight: Style::default().add_modifier(Modifier::REVERSED),
+            visual_selection: Style::default().bg(Color::LightYellow),
+            input_border: Style::default().fg(Color::Magenta),
+            edit_cursor_line: Style::default().add_modifier(Modifier::UNDERLINED),
+        }
+    }
+
+    /// Returns the opposite theme (dark ↔ light).
+    pub fn toggle(&self) -> Self {
+        if self.is_dark {
+            Self::light()
+        } else {
+            Self::dark()
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn dark_theme_active_border_is_cyan() {
+        let theme = Theme::dark();
+        assert_eq!(theme.active_border, Style::default().fg(Color::Cyan));
+    }
+
+    #[test]
+    fn dark_theme_is_dark_flag() {
+        assert!(Theme::dark().is_dark);
+    }
+
+    #[test]
+    fn light_theme_is_not_dark() {
+        assert!(!Theme::light().is_dark);
+    }
+
+    #[test]
+    fn dark_theme_matches_original_hardcoded_values() {
+        let t = Theme::dark();
+        assert_eq!(t.active_border, Style::default().fg(Color::Cyan));
+        assert_eq!(t.inactive_border, Style::default());
+        assert_eq!(
+            t.active_tab,
+            Style::default()
+                .fg(Color::Cyan)
+                .add_modifier(Modifier::BOLD)
+        );
+        assert_eq!(t.inactive_tab, Style::default().fg(Color::DarkGray));
+        assert_eq!(
+            t.help_key,
+            Style::default()
+                .fg(Color::Cyan)
+                .bg(Color::DarkGray)
+                .add_modifier(Modifier::BOLD)
+        );
+        assert_eq!(t.help_desc, Style::default().fg(Color::Gray));
+        assert_eq!(
+            t.highlight,
+            Style::default().add_modifier(Modifier::REVERSED)
+        );
+        assert_eq!(t.visual_selection, Style::default().bg(Color::DarkGray));
+        assert_eq!(t.input_border, Style::default().fg(Color::Yellow));
+        assert_eq!(
+            t.edit_cursor_line,
+            Style::default().add_modifier(Modifier::UNDERLINED)
+        );
+    }
+
+    #[test]
+    fn light_theme_differs_from_dark() {
+        let dark = Theme::dark();
+        let light = Theme::light();
+        assert_ne!(dark.active_border, light.active_border);
+        assert_ne!(dark.input_border, light.input_border);
+        assert_ne!(dark.visual_selection, light.visual_selection);
+    }
+
+    #[test]
+    fn toggle_dark_returns_light() {
+        let dark = Theme::dark();
+        let toggled = dark.toggle();
+        assert!(!toggled.is_dark);
+        assert_eq!(toggled, Theme::light());
+    }
+
+    #[test]
+    fn toggle_light_returns_dark() {
+        let light = Theme::light();
+        let toggled = light.toggle();
+        assert!(toggled.is_dark);
+        assert_eq!(toggled, Theme::dark());
+    }
+
+    #[test]
+    fn double_toggle_returns_original() {
+        let original = Theme::dark();
+        let round_trip = original.toggle().toggle();
+        assert_eq!(original, round_trip);
+    }
+}


### PR DESCRIPTION
## Summary

- Extract 15+ hardcoded inline `Style` definitions from `src/tui/app.rs` into a centralized `Theme` struct in `src/tui/theme.rs`
- 10 semantic UI roles: `active_border`, `inactive_border`, `active_tab`, `inactive_tab`, `help_key`, `help_desc`, `highlight`, `visual_selection`, `input_border`, `edit_cursor_line`
- Built-in dark and light palettes with named terminal colors (respects user's terminal palette)
- Runtime toggle via `T` (shift+t) in Normal mode on both Files and Settings screens
- Dark theme matches existing visual appearance exactly (backward compatible)

Closes #7

## Test plan

- [x] 8 unit tests for `Theme` struct: constructors, field values, toggle, round-trip
- [x] 4 integration tests for `T` key handler: toggles in Normal mode, ignored in Edit/TitleInput modes, works on Settings screen
- [x] All 149 existing tests pass without modification
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)