### PR TITLE
feat: settings memory and smart toggle (#35)

### DIFF
--- a/src/settings.rs
+++ b/src/settings.rs
@@ -1,3 +1,6 @@
+use serde::Deserialize;
+use serde::Serialize;
+use std::env;
 use std::fs;
 use std::path::Path;
 use std::path::PathBuf;
@@ -285,6 +288,12 @@ pub enum SettingsEntry {
     McpServerHeader { file_idx: usize },
     /// A single MCP server entry.
     McpServer { file_idx: usize, name: String },
+    /// An environment variable entry (e.g. "KEY=value").
+    EnvVar {
+        file_idx: usize,
+        name: String,
+        value: String,
+    },
     /// A generic sub-section header (hooks, plugins, env).
     SubHeader { file_idx: usize, key: String },
     /// A generic leaf line (hook entry, plugin name, env var, etc.).
@@ -387,8 +396,19 @@ pub fn build_entry_map(lines: &[String], line_map: &SettingsLineMap) -> Vec<Sett
         }
 
         // Inside generic sub-section
-        if in_sub_section.is_some() {
+        if let Some(ref section_key) = in_sub_section {
             if !trimmed.is_empty() {
+                // Env section: parse "KEY=value" lines
+                if section_key == "Env"
+                    && let Some((name, value)) = parse_env_line(trimmed)
+                {
+                    entries.push(SettingsEntry::EnvVar {
+                        file_idx,
+                        name,
+                        value,
+                    });
+                    continue;
+                }
                 entries.push(SettingsEntry::Leaf { file_idx });
                 continue;
             }
@@ -440,6 +460,17 @@ fn extract_mcp_server_name(trimmed: &str) -> Option<String> {
     Some(trimmed[..colon].to_string())
 }
 
+/// Parses an env var display line like "KEY=value" into (name, value).
+fn parse_env_line(trimmed: &str) -> Option<(String, String)> {
+    let eq = trimmed.find('=')?;
+    if eq == 0 {
+        return None;
+    }
+    let name = trimmed[..eq].to_string();
+    let value = trimmed[eq + 1..].to_string();
+    Some((name, value))
+}
+
 /// Parses a scalar display line like "Model: opus" into (key, value).
 fn parse_scalar_line(trimmed: &str) -> Option<(String, String)> {
     // Map display labels back to JSON keys
@@ -466,6 +497,44 @@ fn parse_scalar_line(trimmed: &str) -> Option<(String, String)> {
     }
 
     None
+}
+
+/// Known enum fields and their allowed values, in cycle order.
+///
+/// Space on a `ScalarField` whose key is in this list will cycle to the next value.
+pub const KNOWN_ENUMS: &[(&str, &[&str])] = &[
+    ("effortLevel", &["high", "medium", "low"]),
+    ("defaultMode", &["plan", "auto"]),
+];
+
+/// Returns the next value in a known enum cycle, or `None` if the key is not a known enum.
+pub fn next_enum_value(key: &str, current: &str) -> Option<&'static str> {
+    for &(enum_key, values) in KNOWN_ENUMS {
+        if enum_key == key {
+            let pos = values.iter().position(|&v| v == current);
+            return match pos {
+                Some(i) => Some(values[(i + 1) % values.len()]),
+                None => Some(values[0]),
+            };
+        }
+    }
+    None
+}
+
+/// Returns true if a string value looks like a binary toggle (0/1, true/false as strings).
+pub fn is_binary_value(value: &str) -> bool {
+    matches!(value, "0" | "1" | "true" | "false")
+}
+
+/// Returns the toggled binary value.
+pub fn toggle_binary_value(value: &str) -> Option<&'static str> {
+    match value {
+        "0" => Some("1"),
+        "1" => Some("0"),
+        "true" => Some("false"),
+        "false" => Some("true"),
+        _ => None,
+    }
 }
 
 /// Writes a settings JSON value back to a file atomically.
@@ -661,6 +730,97 @@ fn format_env(val: &serde_json::Value, lines: &mut Vec<String>) {
     for (key, val) in obj {
         lines.push(format!("    {key}={}", display_scalar(val)));
     }
+}
+
+/// A remembered removed item, stored for easy restoration.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct MemoryItem {
+    /// What kind of item was removed.
+    pub kind: MemoryKind,
+    /// The raw JSON value that was removed (for full restoration).
+    pub value: serde_json::Value,
+    /// Human-readable label for display.
+    pub label: String,
+}
+
+/// The kind of remembered item.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub enum MemoryKind {
+    /// A permission entry (e.g. "Read" from "allow").
+    Permission { category: String },
+    /// An MCP server with its full config.
+    McpServer,
+    /// An environment variable.
+    EnvVar,
+}
+
+/// Persisted memory of recently removed settings entries.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SettingsMemory {
+    #[serde(default)]
+    pub items: Vec<MemoryItem>,
+}
+
+impl SettingsMemory {
+    /// Maximum number of remembered items.
+    const MAX_ITEMS: usize = 50;
+
+    /// Adds an item to memory, deduplicating by label and kind.
+    pub fn remember(&mut self, item: MemoryItem) {
+        // Remove existing item with same label and kind
+        self.items
+            .retain(|existing| existing.label != item.label || existing.kind != item.kind);
+        self.items.insert(0, item);
+        self.items.truncate(Self::MAX_ITEMS);
+    }
+
+    /// Removes an item from memory by index.
+    pub fn forget(&mut self, index: usize) {
+        if index < self.items.len() {
+            self.items.remove(index);
+        }
+    }
+
+    /// Returns items filtered by kind.
+    pub fn items_for_kind(&self, kind: &MemoryKind) -> Vec<(usize, &MemoryItem)> {
+        self.items
+            .iter()
+            .enumerate()
+            .filter(|(_, item)| std::mem::discriminant(&item.kind) == std::mem::discriminant(kind))
+            .collect()
+    }
+}
+
+/// Returns the default memory file path.
+pub fn memory_path() -> Option<PathBuf> {
+    let home = env::var("HOME").ok()?;
+    Some(memory_path_in(&PathBuf::from(home)))
+}
+
+/// Returns the memory file path relative to a given home directory.
+pub fn memory_path_in(home: &Path) -> PathBuf {
+    home.join(".config").join("jigolo").join("memory.toml")
+}
+
+/// Loads the settings memory from the default path.
+pub fn load_memory(path: &Path) -> SettingsMemory {
+    match fs::read_to_string(path) {
+        Ok(contents) => toml::from_str(&contents).unwrap_or_default(),
+        Err(_) => SettingsMemory::default(),
+    }
+}
+
+/// Saves the settings memory to the given path.
+pub fn save_memory(memory: &SettingsMemory, path: &Path) -> anyhow::Result<()> {
+    use anyhow::Context;
+
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("failed to create directory {}", parent.display()))?;
+    }
+    let contents = toml::to_string_pretty(memory).context("failed to serialize memory")?;
+    fs::write(path, contents).with_context(|| format!("failed to write {}", path.display()))?;
+    Ok(())
 }
 
 #[cfg(test)]
@@ -1112,6 +1272,226 @@ mod tests {
         let parsed: serde_json::Value = serde_json::from_str(&content).unwrap();
         assert!(parsed.get("old").is_none());
         assert_eq!(parsed.get("new").unwrap().as_str().unwrap(), "value");
+    }
+
+    // --- EnvVar entry map tests ---
+
+    #[test]
+    fn entry_map_identifies_env_vars() {
+        let collection = collection_from_json(r#"{"env":{"RUST_LOG":"debug","FOO":"bar"}}"#);
+        let (lines, line_map) = format_settings_with_map(&collection);
+        let entries = build_entry_map(&lines, &line_map);
+
+        let env_vars: Vec<_> = entries
+            .iter()
+            .filter_map(|e| match e {
+                SettingsEntry::EnvVar { name, value, .. } => Some((name.as_str(), value.as_str())),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(
+            env_vars.len(),
+            2,
+            "Should find 2 EnvVar entries, got entries: {:?}",
+            entries
+        );
+    }
+
+    #[test]
+    fn entry_map_env_var_has_correct_name_and_value() {
+        let collection =
+            collection_from_json(r#"{"env":{"CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS":"1"}}"#);
+        let (lines, line_map) = format_settings_with_map(&collection);
+        let entries = build_entry_map(&lines, &line_map);
+
+        let env = entries.iter().find_map(|e| match e {
+            SettingsEntry::EnvVar { name, value, .. } => Some((name.clone(), value.clone())),
+            _ => None,
+        });
+        assert_eq!(
+            env,
+            Some((
+                "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS".to_string(),
+                "1".to_string()
+            ))
+        );
+    }
+
+    // --- Smart toggle tests ---
+
+    #[test]
+    fn next_enum_value_cycles_effort_level() {
+        assert_eq!(next_enum_value("effortLevel", "high"), Some("medium"));
+        assert_eq!(next_enum_value("effortLevel", "medium"), Some("low"));
+        assert_eq!(next_enum_value("effortLevel", "low"), Some("high"));
+    }
+
+    #[test]
+    fn next_enum_value_cycles_default_mode() {
+        assert_eq!(next_enum_value("defaultMode", "plan"), Some("auto"));
+        assert_eq!(next_enum_value("defaultMode", "auto"), Some("plan"));
+    }
+
+    #[test]
+    fn next_enum_value_unknown_key_returns_none() {
+        assert_eq!(next_enum_value("model", "opus"), None);
+    }
+
+    #[test]
+    fn next_enum_value_unknown_current_returns_first() {
+        assert_eq!(next_enum_value("effortLevel", "unknown"), Some("high"));
+    }
+
+    #[test]
+    fn toggle_binary_value_flips() {
+        assert_eq!(toggle_binary_value("1"), Some("0"));
+        assert_eq!(toggle_binary_value("0"), Some("1"));
+        assert_eq!(toggle_binary_value("true"), Some("false"));
+        assert_eq!(toggle_binary_value("false"), Some("true"));
+        assert_eq!(toggle_binary_value("opus"), None);
+    }
+
+    #[test]
+    fn is_binary_value_detects_binaries() {
+        assert!(is_binary_value("0"));
+        assert!(is_binary_value("1"));
+        assert!(is_binary_value("true"));
+        assert!(is_binary_value("false"));
+        assert!(!is_binary_value("high"));
+        assert!(!is_binary_value("opus"));
+    }
+
+    // --- Memory tests ---
+
+    #[test]
+    fn memory_remember_adds_item() {
+        let mut memory = SettingsMemory::default();
+        memory.remember(MemoryItem {
+            kind: MemoryKind::Permission {
+                category: "allow".to_string(),
+            },
+            value: serde_json::Value::String("Read".to_string()),
+            label: "Read".to_string(),
+        });
+        assert_eq!(memory.items.len(), 1);
+        assert_eq!(memory.items[0].label, "Read");
+    }
+
+    #[test]
+    fn memory_deduplicates_by_label_and_kind() {
+        let mut memory = SettingsMemory::default();
+        let item = MemoryItem {
+            kind: MemoryKind::Permission {
+                category: "allow".to_string(),
+            },
+            value: serde_json::Value::String("Read".to_string()),
+            label: "Read".to_string(),
+        };
+        memory.remember(item.clone());
+        memory.remember(item);
+        assert_eq!(memory.items.len(), 1);
+    }
+
+    #[test]
+    fn memory_most_recent_first() {
+        let mut memory = SettingsMemory::default();
+        memory.remember(MemoryItem {
+            kind: MemoryKind::Permission {
+                category: "allow".to_string(),
+            },
+            value: serde_json::Value::String("Read".to_string()),
+            label: "Read".to_string(),
+        });
+        memory.remember(MemoryItem {
+            kind: MemoryKind::Permission {
+                category: "allow".to_string(),
+            },
+            value: serde_json::Value::String("Write".to_string()),
+            label: "Write".to_string(),
+        });
+        assert_eq!(memory.items[0].label, "Write");
+        assert_eq!(memory.items[1].label, "Read");
+    }
+
+    #[test]
+    fn memory_forget_removes_by_index() {
+        let mut memory = SettingsMemory::default();
+        memory.remember(MemoryItem {
+            kind: MemoryKind::Permission {
+                category: "allow".to_string(),
+            },
+            value: serde_json::Value::String("Read".to_string()),
+            label: "Read".to_string(),
+        });
+        memory.forget(0);
+        assert!(memory.items.is_empty());
+    }
+
+    #[test]
+    fn memory_items_for_kind_filters() {
+        let mut memory = SettingsMemory::default();
+        memory.remember(MemoryItem {
+            kind: MemoryKind::Permission {
+                category: "allow".to_string(),
+            },
+            value: serde_json::Value::String("Read".to_string()),
+            label: "Read".to_string(),
+        });
+        memory.remember(MemoryItem {
+            kind: MemoryKind::McpServer,
+            value: serde_json::json!({"command": "npx"}),
+            label: "rust-cargo".to_string(),
+        });
+
+        let perms = memory.items_for_kind(&MemoryKind::Permission {
+            category: String::new(),
+        });
+        assert_eq!(perms.len(), 1);
+        assert_eq!(perms[0].1.label, "Read");
+    }
+
+    #[test]
+    fn memory_round_trip_save_load() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("memory.toml");
+
+        let mut memory = SettingsMemory::default();
+        memory.remember(MemoryItem {
+            kind: MemoryKind::Permission {
+                category: "allow".to_string(),
+            },
+            value: serde_json::Value::String("Bash".to_string()),
+            label: "Bash".to_string(),
+        });
+
+        save_memory(&memory, &path).unwrap();
+        let loaded = load_memory(&path);
+
+        assert_eq!(loaded, memory);
+    }
+
+    #[test]
+    fn memory_load_missing_returns_default() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("nonexistent.toml");
+
+        let memory = load_memory(&path);
+        assert!(memory.items.is_empty());
+    }
+
+    #[test]
+    fn memory_truncates_at_max() {
+        let mut memory = SettingsMemory::default();
+        for i in 0..60 {
+            memory.remember(MemoryItem {
+                kind: MemoryKind::Permission {
+                    category: "allow".to_string(),
+                },
+                value: serde_json::Value::String(format!("item-{i}")),
+                label: format!("item-{i}"),
+            });
+        }
+        assert_eq!(memory.items.len(), SettingsMemory::MAX_ITEMS);
     }
 
     #[test]

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -29,6 +29,9 @@ use crate::model::SourceRoot;
 use crate::settings::SettingsCollection;
 use crate::settings::SettingsEntry;
 use crate::settings::SettingsLineMap;
+use crate::settings::SettingsMemory;
+use crate::settings::next_enum_value;
+use crate::settings::toggle_binary_value;
 use crate::tui::theme::Theme;
 
 pub type TreeId = String;
@@ -164,6 +167,8 @@ pub struct SettingsState {
     pub collapsed: HashSet<usize>,
     /// Target for add-permission input: (file_idx, category).
     pub add_target: Option<(usize, String)>,
+    /// Memory of recently removed settings entries.
+    pub memory: SettingsMemory,
 }
 
 impl SettingsState {
@@ -503,8 +508,18 @@ impl App {
                     .get(self.settings_state.cursor)
                 {
                     match entry {
-                        SettingsEntry::BooleanField { .. } => {
+                        SettingsEntry::BooleanField { .. } | SettingsEntry::EnvVar { .. } => {
                             pairs.push(("Space", "Toggle"));
+                            if matches!(entry, SettingsEntry::EnvVar { .. }) {
+                                pairs.push(("d", "Remove"));
+                            }
+                        }
+                        SettingsEntry::ScalarField { key, value, .. } => {
+                            if next_enum_value(key, value).is_some()
+                                || toggle_binary_value(value).is_some()
+                            {
+                                pairs.push(("Space", "Toggle"));
+                            }
                         }
                         SettingsEntry::PermissionItem { .. } => {
                             pairs.push(("a", "Add"));
@@ -518,6 +533,9 @@ impl App {
                         }
                         _ => {}
                     }
+                }
+                if !self.settings_state.memory.items.is_empty() {
+                    pairs.push(("r", "Restore"));
                 }
                 pairs.extend_from_slice(&[
                     ("↑/↓", "Scroll"),

--- a/src/tui/settings.rs
+++ b/src/tui/settings.rs
@@ -17,11 +17,15 @@ use ratatui::widgets::ScrollbarState;
 use super::app::App;
 use super::app::Mode;
 use super::app::Screen;
+use crate::settings::MemoryItem;
+use crate::settings::MemoryKind;
 use crate::settings::SettingsCollection;
 use crate::settings::SettingsEntry;
 use crate::settings::SettingsFile;
 use crate::settings::build_entry_map;
 use crate::settings::format_settings_with_map;
+use crate::settings::next_enum_value;
+use crate::settings::toggle_binary_value;
 use crate::settings::write_settings_file;
 
 impl App {
@@ -104,6 +108,9 @@ impl App {
                 self.status_message =
                     Some("Add not available in merged view — press m to switch.".to_string());
             }
+            KeyCode::Char('r') if !self.settings_state.merged_view => {
+                self.restore_from_memory();
+            }
             KeyCode::Char('q') => self.exit = true,
             KeyCode::Down | KeyCode::Char('j') => {
                 self.settings_state.cursor_down();
@@ -141,7 +148,7 @@ impl App {
         }
     }
 
-    /// Toggles a boolean field at the cursor.
+    /// Toggles/cycles a value at the cursor: booleans, enums, binary env vars.
     fn toggle_settings_value(&mut self) {
         let cursor = self.settings_state.cursor;
         let entry = match self.settings_state.entry_map.get(cursor) {
@@ -162,13 +169,66 @@ impl App {
                     self.status_message = Some(format!("{key} set to {new_value}."));
                 }
             }
+            SettingsEntry::ScalarField {
+                file_idx,
+                ref key,
+                ref value,
+            } => {
+                // Try known enum cycle first
+                if let Some(next) = next_enum_value(key, value) {
+                    let k = key.clone();
+                    let next_val = next.to_string();
+                    if self.mutate_settings_json(file_idx, |obj| {
+                        obj.insert(k, serde_json::Value::String(next_val.clone()));
+                    }) {
+                        self.status_message = Some(format!("{key} set to {next_val}."));
+                    }
+                } else if let Some(toggled) = toggle_binary_value(value) {
+                    // Try binary string toggle (true/false, 0/1 as strings)
+                    let k = key.clone();
+                    let toggled_val = toggled.to_string();
+                    if self.mutate_settings_json(file_idx, |obj| {
+                        obj.insert(k, serde_json::Value::String(toggled_val.clone()));
+                    }) {
+                        self.status_message = Some(format!("{key} set to {toggled_val}."));
+                    }
+                } else {
+                    self.status_message = Some(format!("{key} is not a toggleable field."));
+                }
+            }
+            SettingsEntry::EnvVar {
+                file_idx,
+                ref name,
+                ref value,
+            } => {
+                if let Some(toggled) = toggle_binary_value(value) {
+                    let env_name = name.clone();
+                    let toggled_val = toggled.to_string();
+                    if self.mutate_settings_json(file_idx, |obj| {
+                        let env = obj
+                            .entry("env")
+                            .or_insert_with(|| serde_json::Value::Object(serde_json::Map::new()));
+                        if let Some(env_obj) = env.as_object_mut() {
+                            env_obj.insert(
+                                env_name.clone(),
+                                serde_json::Value::String(toggled_val.clone()),
+                            );
+                        }
+                    }) {
+                        self.status_message = Some(format!("{name} set to {toggled}."));
+                    }
+                } else {
+                    self.status_message = Some(format!("{name} is not a binary value (0/1)."));
+                }
+            }
             _ => {
-                self.status_message = Some("Space toggles boolean fields only.".to_string());
+                self.status_message = Some("Not a toggleable field.".to_string());
             }
         }
     }
 
-    /// Deletes a permission item or MCP server at the cursor.
+    /// Deletes a permission item, MCP server, or env var at the cursor.
+    /// Removed items are saved to memory for easy restoration.
     fn delete_settings_entry(&mut self) {
         let cursor = self.settings_state.cursor;
         let entry = match self.settings_state.entry_map.get(cursor) {
@@ -193,11 +253,30 @@ impl App {
                         arr.retain(|item| item.as_str() != Some(&val));
                     }
                 }) {
-                    self.status_message = Some(format!("Removed '{val}' from {cat}."));
+                    self.settings_state.memory.remember(MemoryItem {
+                        kind: MemoryKind::Permission {
+                            category: cat.clone(),
+                        },
+                        value: serde_json::Value::String(val.clone()),
+                        label: val.clone(),
+                    });
+                    self.save_settings_memory();
+                    self.status_message =
+                        Some(format!("Removed '{val}' from {cat}. Press r to restore."));
                 }
             }
             SettingsEntry::McpServer { file_idx, ref name } => {
                 let server_name = name.clone();
+                // Capture the full server config before removing
+                let server_config = self
+                    .settings_collection
+                    .as_ref()
+                    .and_then(|c| c.files.get(file_idx))
+                    .and_then(|f| f.value.get("mcpServers"))
+                    .and_then(|s| s.get(&server_name))
+                    .cloned()
+                    .unwrap_or(serde_json::Value::Null);
+
                 if self.mutate_settings_json(file_idx, |obj| {
                     if let Some(servers) = obj.get_mut("mcpServers")
                         && let Some(servers_obj) = servers.as_object_mut()
@@ -205,12 +284,49 @@ impl App {
                         servers_obj.remove(&server_name);
                     }
                 }) {
-                    self.status_message = Some(format!("Removed MCP server '{server_name}'."));
+                    self.settings_state.memory.remember(MemoryItem {
+                        kind: MemoryKind::McpServer,
+                        value: serde_json::json!({
+                            "name": server_name,
+                            "config": server_config,
+                        }),
+                        label: server_name.clone(),
+                    });
+                    self.save_settings_memory();
+                    self.status_message = Some(format!(
+                        "Removed MCP server '{server_name}'. Press r to restore."
+                    ));
+                }
+            }
+            SettingsEntry::EnvVar {
+                file_idx,
+                ref name,
+                ref value,
+            } => {
+                let env_name = name.clone();
+                let env_value = value.clone();
+                if self.mutate_settings_json(file_idx, |obj| {
+                    if let Some(env) = obj.get_mut("env")
+                        && let Some(env_obj) = env.as_object_mut()
+                    {
+                        env_obj.remove(&env_name);
+                    }
+                }) {
+                    self.settings_state.memory.remember(MemoryItem {
+                        kind: MemoryKind::EnvVar,
+                        value: serde_json::json!({
+                            "name": env_name,
+                            "value": env_value,
+                        }),
+                        label: format!("{env_name}={env_value}"),
+                    });
+                    self.save_settings_memory();
+                    self.status_message = Some(format!("Removed {env_name}. Press r to restore."));
                 }
             }
             _ => {
                 self.status_message =
-                    Some("Delete works on permission items and MCP servers.".to_string());
+                    Some("Delete works on permissions, MCP servers, and env vars.".to_string());
             }
         }
     }
@@ -279,6 +395,105 @@ impl App {
         self.reset_to_normal();
     }
 
+    /// Restores the most recent memory item, applying it to the first settings file.
+    fn restore_from_memory(&mut self) {
+        if self.settings_state.memory.items.is_empty() {
+            self.status_message = Some("Memory is empty — nothing to restore.".to_string());
+            return;
+        }
+
+        let item = self.settings_state.memory.items[0].clone();
+
+        // Determine which file to restore to (use first/global file)
+        let file_idx = 0;
+
+        let success = match &item.kind {
+            MemoryKind::Permission { category } => {
+                let cat = category.clone();
+                let val = item.value.clone();
+                self.mutate_settings_json(file_idx, |obj| {
+                    let perms = obj
+                        .entry("permissions")
+                        .or_insert_with(|| serde_json::Value::Object(serde_json::Map::new()));
+                    if let Some(perms_obj) = perms.as_object_mut() {
+                        let arr = perms_obj
+                            .entry(&cat)
+                            .or_insert_with(|| serde_json::Value::Array(Vec::new()));
+                        if let Some(arr) = arr.as_array_mut()
+                            && !arr.contains(&val)
+                        {
+                            arr.push(val);
+                        }
+                    }
+                })
+            }
+            MemoryKind::McpServer => {
+                let name = item
+                    .value
+                    .get("name")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_string();
+                let config = item
+                    .value
+                    .get("config")
+                    .cloned()
+                    .unwrap_or(serde_json::Value::Null);
+                self.mutate_settings_json(file_idx, |obj| {
+                    let servers = obj
+                        .entry("mcpServers")
+                        .or_insert_with(|| serde_json::Value::Object(serde_json::Map::new()));
+                    if let Some(servers_obj) = servers.as_object_mut() {
+                        servers_obj.insert(name.clone(), config);
+                    }
+                })
+            }
+            MemoryKind::EnvVar => {
+                let name = item
+                    .value
+                    .get("name")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_string();
+                let val = item
+                    .value
+                    .get("value")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_string();
+                self.mutate_settings_json(file_idx, |obj| {
+                    let env = obj
+                        .entry("env")
+                        .or_insert_with(|| serde_json::Value::Object(serde_json::Map::new()));
+                    if let Some(env_obj) = env.as_object_mut() {
+                        env_obj.insert(name.clone(), serde_json::Value::String(val));
+                    }
+                })
+            }
+        };
+
+        if success {
+            let label = item.label.clone();
+            self.settings_state.memory.forget(0);
+            self.save_settings_memory();
+            self.status_message = Some(format!("Restored '{label}'."));
+        }
+    }
+
+    /// Saves the settings memory to disk.
+    fn save_settings_memory(&self) {
+        if let Some(path) = crate::settings::memory_path() {
+            let _ = crate::settings::save_memory(&self.settings_state.memory, &path);
+        }
+    }
+
+    /// Loads settings memory on entering the settings screen.
+    pub(crate) fn load_settings_memory(&mut self) {
+        if let Some(path) = crate::settings::memory_path() {
+            self.settings_state.memory = crate::settings::load_memory(&path);
+        }
+    }
+
     /// Applies a mutation to the JSON object in a settings file, writes it back,
     /// and rebuilds the display. Returns true on success.
     fn mutate_settings_json(
@@ -330,6 +545,7 @@ impl App {
     pub fn switch_to_settings_from(&mut self, project: &Path) {
         let collection = crate::settings::discover_settings_files(project);
         self.apply_settings_collection(collection);
+        self.load_settings_memory();
         self.screen = Screen::Settings;
     }
 
@@ -873,13 +1089,20 @@ mod tests {
     }
 
     #[test]
-    fn space_on_non_boolean_shows_message() {
+    fn space_on_non_toggleable_shows_message() {
         let (mut app, _tmp) = settings_app_with_file(r#"{"model":"opus"}"#);
         app.settings_state.cursor = 0; // Section header
 
         app.handle_key_event(key_event(KeyCode::Char(' ')));
 
-        assert!(app.status_message.as_deref().unwrap().contains("boolean"),);
+        assert!(
+            app.status_message
+                .as_deref()
+                .unwrap()
+                .contains("toggleable"),
+            "Should show not-toggleable message, got: {:?}",
+            app.status_message
+        );
     }
 
     #[test]
@@ -1120,6 +1343,224 @@ mod tests {
         assert!(
             help_text.contains("Add") && help_text.contains("Remove"),
             "Help bar should show Add and Remove on permission item, got: {help_text}"
+        );
+    }
+
+    // --- Smart toggle tests ---
+
+    #[test]
+    fn space_cycles_enum_field() {
+        let (mut app, tmp) = settings_app_with_file(r#"{"effortLevel":"high"}"#);
+
+        let scalar_idx = app
+            .settings_state
+            .entry_map
+            .iter()
+            .position(|e| {
+                matches!(e, crate::settings::SettingsEntry::ScalarField { key, .. } if key == "effortLevel")
+            })
+            .unwrap();
+        app.settings_state.cursor = scalar_idx;
+
+        app.handle_key_event(key_event(KeyCode::Char(' ')));
+
+        let settings_file = tmp.path().join(".claude/settings.json");
+        let content = fs::read_to_string(&settings_file).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&content).unwrap();
+        assert_eq!(
+            parsed.get("effortLevel").unwrap().as_str().unwrap(),
+            "medium",
+            "Should cycle from high to medium"
+        );
+    }
+
+    #[test]
+    fn space_toggles_binary_env_var() {
+        let (mut app, tmp) =
+            settings_app_with_file(r#"{"env":{"CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS":"1"}}"#);
+
+        let env_idx = app
+            .settings_state
+            .entry_map
+            .iter()
+            .position(|e| matches!(e, crate::settings::SettingsEntry::EnvVar { .. }))
+            .unwrap();
+        app.settings_state.cursor = env_idx;
+
+        app.handle_key_event(key_event(KeyCode::Char(' ')));
+
+        let settings_file = tmp.path().join(".claude/settings.json");
+        let content = fs::read_to_string(&settings_file).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&content).unwrap();
+        assert_eq!(
+            parsed
+                .get("env")
+                .unwrap()
+                .get("CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS")
+                .unwrap()
+                .as_str()
+                .unwrap(),
+            "0",
+            "Should toggle from 1 to 0"
+        );
+    }
+
+    #[test]
+    fn space_on_non_binary_env_var_shows_message() {
+        let (mut app, _tmp) = settings_app_with_file(r#"{"env":{"RUST_LOG":"debug"}}"#);
+
+        let env_idx = app
+            .settings_state
+            .entry_map
+            .iter()
+            .position(|e| matches!(e, crate::settings::SettingsEntry::EnvVar { .. }))
+            .unwrap();
+        app.settings_state.cursor = env_idx;
+
+        app.handle_key_event(key_event(KeyCode::Char(' ')));
+
+        assert!(
+            app.status_message.as_deref().unwrap().contains("binary"),
+            "Should show binary message, got: {:?}",
+            app.status_message
+        );
+    }
+
+    // --- Memory tests ---
+
+    #[test]
+    fn d_on_permission_saves_to_memory() {
+        let (mut app, _tmp) =
+            settings_app_with_file(r#"{"permissions":{"allow":["Read","Write"]}}"#);
+
+        let item_idx = app
+            .settings_state
+            .entry_map
+            .iter()
+            .position(|e| {
+                matches!(e, crate::settings::SettingsEntry::PermissionItem { value, .. } if value == "Read")
+            })
+            .unwrap();
+        app.settings_state.cursor = item_idx;
+
+        app.handle_key_event(key_event(KeyCode::Char('d')));
+
+        assert_eq!(app.settings_state.memory.items.len(), 1);
+        assert_eq!(app.settings_state.memory.items[0].label, "Read");
+    }
+
+    #[test]
+    fn r_restores_from_memory() {
+        let (mut app, tmp) =
+            settings_app_with_file(r#"{"permissions":{"allow":["Read","Write"]}}"#);
+
+        // Remove Read
+        let item_idx = app
+            .settings_state
+            .entry_map
+            .iter()
+            .position(|e| {
+                matches!(e, crate::settings::SettingsEntry::PermissionItem { value, .. } if value == "Read")
+            })
+            .unwrap();
+        app.settings_state.cursor = item_idx;
+        app.handle_key_event(key_event(KeyCode::Char('d')));
+
+        // Verify it was removed
+        let settings_file = tmp.path().join(".claude/settings.json");
+        let content = fs::read_to_string(&settings_file).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&content).unwrap();
+        let allow = parsed
+            .get("permissions")
+            .unwrap()
+            .get("allow")
+            .unwrap()
+            .as_array()
+            .unwrap();
+        assert!(!allow.iter().any(|v| v.as_str() == Some("Read")));
+
+        // Now restore
+        app.handle_key_event(key_event(KeyCode::Char('r')));
+
+        // Verify it was restored
+        let content = fs::read_to_string(&settings_file).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&content).unwrap();
+        let allow = parsed
+            .get("permissions")
+            .unwrap()
+            .get("allow")
+            .unwrap()
+            .as_array()
+            .unwrap();
+        assert!(
+            allow.iter().any(|v| v.as_str() == Some("Read")),
+            "Read should be restored"
+        );
+
+        // Memory should be cleared
+        assert!(app.settings_state.memory.items.is_empty());
+    }
+
+    #[test]
+    fn r_on_empty_memory_shows_message() {
+        let (mut app, _tmp) = settings_app_with_file(r#"{"model":"opus"}"#);
+
+        app.handle_key_event(key_event(KeyCode::Char('r')));
+
+        assert!(
+            app.status_message.as_deref().unwrap().contains("empty"),
+            "Should show empty memory message, got: {:?}",
+            app.status_message
+        );
+    }
+
+    #[test]
+    fn d_on_env_var_saves_to_memory_and_removes() {
+        let (mut app, tmp) = settings_app_with_file(
+            r#"{"env":{"CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS":"1","FOO":"bar"}}"#,
+        );
+
+        let env_idx = app
+            .settings_state
+            .entry_map
+            .iter()
+            .position(|e| {
+                matches!(e, crate::settings::SettingsEntry::EnvVar { name, .. } if name == "FOO")
+            })
+            .unwrap();
+        app.settings_state.cursor = env_idx;
+
+        app.handle_key_event(key_event(KeyCode::Char('d')));
+
+        // Verify removed from file
+        let settings_file = tmp.path().join(".claude/settings.json");
+        let content = fs::read_to_string(&settings_file).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&content).unwrap();
+        assert!(parsed.get("env").unwrap().get("FOO").is_none());
+
+        // Verify in memory
+        assert_eq!(app.settings_state.memory.items.len(), 1);
+        assert_eq!(app.settings_state.memory.items[0].label, "FOO=bar");
+    }
+
+    #[test]
+    fn help_bar_shows_restore_when_memory_has_items() {
+        let (mut app, _tmp) = settings_app_with_file(r#"{"model":"opus"}"#);
+        app.settings_state
+            .memory
+            .remember(crate::settings::MemoryItem {
+                kind: crate::settings::MemoryKind::Permission {
+                    category: "allow".to_string(),
+                },
+                value: serde_json::Value::String("Read".to_string()),
+                label: "Read".to_string(),
+            });
+
+        let help = app.help_line();
+        let help_text: String = help.spans.iter().map(|s| s.content.to_string()).collect();
+        assert!(
+            help_text.contains("Restore"),
+            "Help bar should show Restore when memory has items, got: {help_text}"
         );
     }
 


### PR DESCRIPTION
## Summary

Builds on #34 to add **memory** (undo for removes) and **smart toggle** for enums and binary env vars.

### Memory
- **d** now saves removed items to a recoverable memory list (persisted in `~/.config/jigolo/memory.toml`)
- **r** restores the most recently removed item back to the settings file
- Works for permissions, MCP servers, and env vars
- MCP servers save their full config, so restoration is lossless
- Memory deduplicates and caps at 50 items

### Smart Toggle (Space)
| Entry type | Behavior |
|---|---|
| Boolean field (`thinking: true`) | Toggle true/false |
| Enum field (`effortLevel: high`) | Cycle: high → medium → low → high |
| Enum field (`defaultMode: plan`) | Cycle: plan → auto → plan |
| Binary env var (`FEATURE=1`) | Toggle 0/1 |
| String boolean (`"true"`) | Toggle "true"/"false" |
| Non-toggleable | Shows "not toggleable" message |

### New: EnvVar entry type
- Env var lines (`KEY=value`) are now parsed as `SettingsEntry::EnvVar`
- **d** removes env vars (saved to memory)
- **Space** toggles binary env vars (0/1)

Closes #35

## Test plan

- [x] 268 unit tests pass (25 new)
- [x] 8 integration tests pass
- [x] Clippy clean
- [x] `cargo fmt` applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)